### PR TITLE
feat(browser): show browser launch banner if mobile browser is installed

### DIFF
--- a/MobileSnapp/MobileSnapp.Android/MainActivity.cs
+++ b/MobileSnapp/MobileSnapp.Android/MainActivity.cs
@@ -11,6 +11,7 @@ using Android.App;
 using Android.Content.PM;
 using Android.OS;
 using Android.Runtime;
+using Plugin.CurrentActivity;
 using Xamarin.Forms;
 
 namespace MobileSnapp.Droid
@@ -29,6 +30,7 @@ namespace MobileSnapp.Droid
             ToolbarResource = Resource.Layout.Toolbar;
 
             base.OnCreate(savedInstanceState);
+            CrossCurrentActivity.Current.Init(this, savedInstanceState);
             Forms.SetFlags("CarouselView_Experimental");
             Xamarin.Essentials.Platform.Init(this, savedInstanceState);
             global::Xamarin.Forms.Forms.Init(this, savedInstanceState);

--- a/MobileSnapp/MobileSnapp.Android/MobileSnapp.Android.csproj
+++ b/MobileSnapp/MobileSnapp.Android/MobileSnapp.Android.csproj
@@ -65,12 +65,16 @@
     <PackageReference Include="Xamarin.Forms.Visual.Material">
       <Version>4.3.0.991211</Version>
     </PackageReference>
+    <PackageReference Include="Plugin.CurrentActivity">
+      <Version>2.1.0.4</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Resources\Resource.designer.cs" />
     <Compile Include="ControlRenderers\ShadowBoxViewRenderer.cs" />
+    <Compile Include="PlatformServices\PlatformService.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Properties\AndroidManifest.xml" />
@@ -115,6 +119,7 @@
     <Folder Include="Resources\drawable-xxxhdpi\" />
     <Folder Include="Resources\drawable\" />
     <Folder Include="ControlRenderers\" />
+    <Folder Include="PlatformServices\" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MobileSnapp\MobileSnapp.csproj">

--- a/MobileSnapp/MobileSnapp.Android/PlatformServices/PlatformService.cs
+++ b/MobileSnapp/MobileSnapp.Android/PlatformServices/PlatformService.cs
@@ -1,0 +1,33 @@
+﻿using System.Linq;
+using Android.Content;
+using MobileSnapp.Droid.PlatformServices;
+using MobileSnapp.Services;
+using Plugin.CurrentActivity;
+using Xamarin.Forms;
+
+[assembly: Dependency(typeof(PlatformService))]
+
+namespace MobileSnapp.Droid.PlatformServices
+{
+    public class PlatformService : IPlatformService
+    {
+        public bool CanOpenAnAppUsingUrl(string appUrl)
+        {
+            var aUri = Android.Net.Uri.Parse(appUrl);
+            var intent = new Intent(Intent.ActionView, aUri);
+
+            var packageManager = CrossCurrentActivity.Current.AppContext.PackageManager;
+
+            if (packageManager != null)
+            {
+                var activities = packageManager.QueryIntentActivities(
+                       intent,
+                       0);
+                var isIntentSafe = activities != null && activities.Any();
+                return isIntentSafe;
+            }
+
+            return false;
+        }
+    }
+}

--- a/MobileSnapp/MobileSnapp.iOS/GlobalSuppressions.cs
+++ b/MobileSnapp/MobileSnapp.iOS/GlobalSuppressions.cs
@@ -11,5 +11,5 @@
 // attributes that are applied to this project.
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
-
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Default namespace for iOS apps", Scope = "namespace", Target = "~N:MobileSnapp.iOS")]
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.NamingRules", "SA1300:Element should begin with upper-case letter", Justification = "Default namespace for iOS apps", Scope = "namespace", Target = "~N:MobileSnapp.iOS.PlatformServices")]

--- a/MobileSnapp/MobileSnapp.iOS/Info.plist
+++ b/MobileSnapp/MobileSnapp.iOS/Info.plist
@@ -38,5 +38,9 @@
 	</array>
 	<key>CFBundleName</key>
 	<string>SAFE Network App</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>safe</string>
+	</array>
 </dict>
 </plist>

--- a/MobileSnapp/MobileSnapp.iOS/MobileSnapp.iOS.csproj
+++ b/MobileSnapp/MobileSnapp.iOS/MobileSnapp.iOS.csproj
@@ -64,6 +64,7 @@
     <None Include="Info.plist" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ControlRenderers\ShadowBoxViewRenderer.cs" />
+    <Compile Include="PlatformServices\PlatformService.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\LaunchScreen.storyboard" />
@@ -155,5 +156,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="ControlRenderers\" />
+    <Folder Include="PlatformServices\" />
   </ItemGroup>
 </Project>

--- a/MobileSnapp/MobileSnapp.iOS/PlatformServices/PlatformService.cs
+++ b/MobileSnapp/MobileSnapp.iOS/PlatformServices/PlatformService.cs
@@ -1,0 +1,18 @@
+﻿using Foundation;
+using MobileSnapp.iOS.PlatformServices;
+using MobileSnapp.Services;
+using UIKit;
+using Xamarin.Forms;
+
+[assembly: Dependency(typeof(PlatformService))]
+
+namespace MobileSnapp.iOS.PlatformServices
+{
+    public class PlatformService : IPlatformService
+    {
+        public bool CanOpenAnAppUsingUrl(string appUrl)
+        {
+            return UIApplication.SharedApplication.CanOpenUrl(new NSUrl(appUrl));
+        }
+    }
+}

--- a/MobileSnapp/MobileSnapp/MobileSnapp.csproj
+++ b/MobileSnapp/MobileSnapp/MobileSnapp.csproj
@@ -55,5 +55,7 @@
     <Folder Include="Views\TemplateSelectors\" />
     <Folder Include="Views\Common\" />
     <Folder Include="ViewModels\Common\" />
+    <Folder Include="Services\" />
+    <Folder Include="Services\Abstractions\" />
   </ItemGroup>
 </Project>

--- a/MobileSnapp/MobileSnapp/Models/IconFont.cs
+++ b/MobileSnapp/MobileSnapp/Models/IconFont.cs
@@ -43,5 +43,6 @@
         public const string Lock = "\uf33e";
         public const string Download = "\uf1da";
         public const string CheckCircleOutline = "\uf5e1";
+        public const string Launch = "\uf327";
     }
 }

--- a/MobileSnapp/MobileSnapp/Services/Abstractions/IPlatformService.cs
+++ b/MobileSnapp/MobileSnapp/Services/Abstractions/IPlatformService.cs
@@ -1,0 +1,7 @@
+﻿namespace MobileSnapp.Services
+{
+    public interface IPlatformService
+    {
+        bool CanOpenAnAppUsingUrl(string appUrl);
+    }
+}

--- a/MobileSnapp/MobileSnapp/ViewModels/Common/BaseViewModel.cs
+++ b/MobileSnapp/MobileSnapp/ViewModels/Common/BaseViewModel.cs
@@ -1,0 +1,11 @@
+﻿using MobileSnapp.Services;
+using Xamarin.Forms;
+
+namespace MobileSnapp.ViewModels.Common
+{
+    public class BaseViewModel : MvvmHelpers.BaseViewModel
+    {
+        public IPlatformService PlatformService =>
+            DependencyService.Get<IPlatformService>();
+    }
+}

--- a/MobileSnapp/MobileSnapp/ViewModels/Common/SettingsViewModel.cs
+++ b/MobileSnapp/MobileSnapp/ViewModels/Common/SettingsViewModel.cs
@@ -7,7 +7,6 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-using MvvmHelpers;
 using Xamarin.Forms;
 
 namespace MobileSnapp.ViewModels.Common

--- a/MobileSnapp/MobileSnapp/ViewModels/Onboarding/AppDetailsViewModel.cs
+++ b/MobileSnapp/MobileSnapp/ViewModels/Onboarding/AppDetailsViewModel.cs
@@ -8,7 +8,7 @@
 // Software.
 
 using System.Windows.Input;
-using MvvmHelpers;
+using MobileSnapp.ViewModels.Common;
 using Xamarin.Forms;
 
 namespace MobileSnapp.ViewModels.Onboarding

--- a/MobileSnapp/MobileSnapp/ViewModels/Onboarding/AppScreenViewModel.cs
+++ b/MobileSnapp/MobileSnapp/ViewModels/Onboarding/AppScreenViewModel.cs
@@ -7,7 +7,7 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-using MvvmHelpers;
+using MobileSnapp.ViewModels.Common;
 
 namespace MobileSnapp.ViewModels.Onboarding
 {

--- a/MobileSnapp/MobileSnapp/ViewModels/Onboarding/CreateAccountOnboardingViewModel.cs
+++ b/MobileSnapp/MobileSnapp/ViewModels/Onboarding/CreateAccountOnboardingViewModel.cs
@@ -11,8 +11,8 @@ using System.Collections.ObjectModel;
 using System.Windows.Input;
 using MobileSnapp.Helpers;
 using MobileSnapp.Models.Onboarding;
+using MobileSnapp.ViewModels.Common;
 using MobileSnapp.Views.Onboarding;
-using MvvmHelpers;
 using Xamarin.Forms;
 
 namespace MobileSnapp.ViewModels.Onboarding

--- a/MobileSnapp/MobileSnapp/ViewModels/Onboarding/CreateAccountOptionsViewModel.cs
+++ b/MobileSnapp/MobileSnapp/ViewModels/Onboarding/CreateAccountOptionsViewModel.cs
@@ -11,8 +11,8 @@ using System.Collections.ObjectModel;
 using System.Windows.Input;
 using MobileSnapp.Helpers;
 using MobileSnapp.Models.Onboarding;
+using MobileSnapp.ViewModels.Common;
 using MobileSnapp.Views.Onboarding;
-using MvvmHelpers;
 using Xamarin.Forms;
 
 namespace MobileSnapp.ViewModels.Onboarding

--- a/MobileSnapp/MobileSnapp/ViewModels/Onboarding/CreateAccountViewModel.cs
+++ b/MobileSnapp/MobileSnapp/ViewModels/Onboarding/CreateAccountViewModel.cs
@@ -9,8 +9,8 @@
 
 using System.Collections.Generic;
 using System.Windows.Input;
+using MobileSnapp.ViewModels.Common;
 using MobileSnapp.Views.Onboarding;
-using MvvmHelpers;
 using Xamarin.Forms;
 
 namespace MobileSnapp.ViewModels.Onboarding

--- a/MobileSnapp/MobileSnapp/ViewModels/Onboarding/LoginViewModel.cs
+++ b/MobileSnapp/MobileSnapp/ViewModels/Onboarding/LoginViewModel.cs
@@ -8,8 +8,8 @@
 // Software.
 
 using System.Windows.Input;
+using MobileSnapp.ViewModels.Common;
 using MobileSnapp.Views.Onboarding;
-using MvvmHelpers;
 using Xamarin.Forms;
 
 namespace MobileSnapp.ViewModels.Onboarding

--- a/MobileSnapp/MobileSnapp/ViewModels/Onboarding/OnboardingLaunchViewModel.cs
+++ b/MobileSnapp/MobileSnapp/ViewModels/Onboarding/OnboardingLaunchViewModel.cs
@@ -7,14 +7,13 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-using System;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Windows.Input;
 using MobileSnapp.Helpers;
 using MobileSnapp.Models.Onboarding;
+using MobileSnapp.ViewModels.Common;
 using MobileSnapp.Views.Onboarding;
-using MvvmHelpers;
 using Xamarin.Forms;
 
 namespace MobileSnapp.ViewModels.Onboarding
@@ -43,12 +42,19 @@ namespace MobileSnapp.ViewModels.Onboarding
         public OnBoardingLaunchViewModel(INavigation navigation)
         {
             _navigation = navigation;
+
             OnBoardingLaunchItems = new ObservableCollection<CarouselItem>(
                ContentHelpers.PopulateData<OnboardingLaunch>(
                    _staticContentFile)
                .CarouselItems);
+
             CarouselViewItemTapCommand = new Command((object secondaryTitle) => PerformCarouselViewItemTapAction(secondaryTitle));
             OpenLoginPageCommand = new Command(() => ShowLoginPage());
+
+            // Check is the browser is install
+            var canOpenTestUrl = PlatformService.CanOpenAnAppUsingUrl("safe://testapp.net");
+            if (canOpenTestUrl)
+                IsBrowserInstalled = true;
         }
 
         private void ShowLoginPage()
@@ -94,6 +100,14 @@ namespace MobileSnapp.ViewModels.Onboarding
         {
             get => _boardings;
             set => SetProperty(ref _boardings, value);
+        }
+
+        private bool _isBrowserInstalled;
+
+        public bool IsBrowserInstalled
+        {
+            get => _isBrowserInstalled;
+            set => SetProperty(ref _isBrowserInstalled, value);
         }
 
         #endregion

--- a/MobileSnapp/MobileSnapp/Views/OnBoarding/OnboardingLaunchPage.xaml
+++ b/MobileSnapp/MobileSnapp/Views/OnBoarding/OnboardingLaunchPage.xaml
@@ -4,6 +4,7 @@
              xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:customViews="clr-namespace:MobileSnapp.Views.CustomViews"
+             xmlns:icons="clr-namespace:MobileSnapp.Models"
              xmlns:vm="clr-namespace:MobileSnapp.ViewModels.Onboarding"
              xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
              ios:Page.PrefersHomeIndicatorAutoHidden="true"
@@ -28,7 +29,37 @@
         <StackLayout Spacing="0"
                      Orientation="Vertical"
                      BackgroundColor="{StaticResource PrimaryColor}">
-            <Label Text="Getting Started"
+
+            <!--Browser launch header-->
+            <Label Text="BROWSE SAFE"
+                   Style="{StaticResource PrimaryLightLabelStyle}"
+                   VerticalOptions="EndAndExpand"
+                   Margin="20, 0"
+                   IsVisible="{Binding IsBrowserInstalled}" />
+            <StackLayout BackgroundColor="DarkSlateBlue"
+                         Orientation="Horizontal"
+                         Padding="20, 10"
+                         Margin="0, 10"
+                         Spacing="15"
+                         IsVisible="{Binding IsBrowserInstalled}">
+                <Image Source="browser"
+                       VerticalOptions="Center"
+                       HeightRequest="40"
+                       WidthRequest="40" />
+                <Label Text="SAFE Browser"
+                       FontSize="Medium"
+                       TextColor="White"
+                       VerticalOptions="Center" />
+                <Label FontFamily="{StaticResource MaterialFontFamily}"
+                       TextColor="DarkGray"
+                       HorizontalOptions="EndAndExpand"
+                       VerticalOptions="Center"
+                       FontSize="Large"
+                       Text="{x:Static icons:IconFont.Launch}" />
+            </StackLayout>
+
+            <!--App launch options-->
+            <Label Text="GETTING STARTED"
                    Style="{StaticResource PrimaryLightLabelStyle}"
                    VerticalOptions="EndAndExpand"
                    Margin="20, 0" />
@@ -112,6 +143,8 @@
                     </DataTemplate>
                 </CarouselView.ItemTemplate>
             </CarouselView>
+
+            <!--Login sheet-->
             <StackLayout Orientation="Vertical"
                          VerticalOptions="EndAndExpand"
                          HorizontalOptions="FillAndExpand"


### PR DESCRIPTION
**Changes:**
- Show browser installed banner when the mobile browser already installed on the device.
- Use the package manager on Android to check if the browser is installed.
- Use SharedApplication API on iOS to check is `safe://` a URL can be opened to check if the browser is installed.

_**Note:** Styling pending_